### PR TITLE
Mostrar horarios del restaurante by Orlando

### DIFF
--- a/src/features/menu-billy-blanco-orlando/RestaurantMenu.jsx
+++ b/src/features/menu-billy-blanco-orlando/RestaurantMenu.jsx
@@ -3,6 +3,7 @@ import DataMenu from "#src/data/client.json";
 import MenuHeader from "./components/MenuHeader";
 import MenuSection from "./components/MenuSection";
 import MenuSurvey from "./components/MenuSurvey";
+import MenuSchedule from "./components/MenuSchedule";
 
 function RestaurantMenu() {
   const [language, setLanguage] = useState(DataMenu.intl.defaultLanguage);
@@ -45,6 +46,8 @@ function RestaurantMenu() {
         language={language}
         currency={currency}
       />
+
+      <MenuSchedule schedule={DataMenu.schedule} language={language} />
 
       <MenuSurvey
         survey={DataMenu.survey}

--- a/src/features/menu-billy-blanco-orlando/components/MenuHeader.jsx
+++ b/src/features/menu-billy-blanco-orlando/components/MenuHeader.jsx
@@ -16,7 +16,7 @@ export default function MenuHeader({
         <div className="flex items-center gap-4">
           <img
             src={
-              "https://scontent.fmex31-1.fna.fbcdn.net/v/t39.30808-6/263638995_109836721536269_961652445950806142_n.jpg?_nc_cat=109&ccb=1-7&_nc_sid=6ee11a&_nc_ohc=srVUxedC-BcQ7kNvwGoLcpc&_nc_oc=AdknwBERPjEKiNcKjeELa3mCBbk-QZ8JKofCumvtebSLCqkjftl0fCIiBWWCtuG5O7Asgn5HmMfh7wDqkolvQMnR&_nc_zt=23&_nc_ht=scontent.fmex31-1.fna&_nc_gid=JVrg1U7swX-QUVWEyK3GCg&oh=00_Afj1dT2pzEcVov1t_0ZbwTDakXCffbY5dBJCbxZYFWIcIQ&oe=691E497C"
+              "https://zalits-hermes-bucket.sfo2.cdn.digitaloceanspaces.com/iris/p/019a5cd9-f468-7e4f-99e4-a3d1058c2fc2.jpg"
             }
             alt="Restaurant Logo"
             className="w-20 h-20 rounded-full object-cover border-2 border-orange-300"

--- a/src/features/menu-billy-blanco-orlando/components/MenuHeader.jsx
+++ b/src/features/menu-billy-blanco-orlando/components/MenuHeader.jsx
@@ -1,4 +1,5 @@
 import { text } from "../helpers/text";
+import { getScheduleStatus } from "../helpers/schedule";
 
 export default function MenuHeader({
   dataMenu,
@@ -6,6 +7,9 @@ export default function MenuHeader({
   handlerLanguage,
   handlerCurrency,
 }) {
+
+  const scheduleStatus = getScheduleStatus(dataMenu.schedule, language);
+
   return (
     <header className="bg-white rounded-lg p-6 shadow-sm border border-orange-200">
       <div className="flex items-center justify-between flex-wrap gap-4 mb-6">
@@ -33,11 +37,10 @@ export default function MenuHeader({
               handlerLanguage("es");
               handlerCurrency("mxn");
             }}
-            className={`px-5 py-2 rounded-lg font-semibold transition-all ${
-              language === "es"
-                ? "bg-orange-500 text-white"
-                : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-            }`}
+            className={`px-5 py-2 rounded-lg font-semibold transition-all ${language === "es"
+              ? "bg-orange-500 text-white"
+              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+              }`}
           >
             ES
           </button>
@@ -46,11 +49,10 @@ export default function MenuHeader({
               handlerLanguage("en");
               handlerCurrency("usd");
             }}
-            className={`px-5 py-2 rounded-lg font-semibold transition-all ${
-              language === "en"
-                ? "bg-orange-500 text-white"
-                : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-            }`}
+            className={`px-5 py-2 rounded-lg font-semibold transition-all ${language === "en"
+              ? "bg-orange-500 text-white"
+              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+              }`}
           >
             EN
           </button>
@@ -72,6 +74,15 @@ export default function MenuHeader({
           <p className="font-semibold text-orange-600 mb-1">Contacto</p>
           <p>{dataMenu.contact.phone}</p>
           <p>{dataMenu.contact.email}</p>
+        </div>
+
+        <div className="mt-3 pt-3 border-t border-gray-200">
+          <p
+            className={`font-semibold text-sm ${scheduleStatus.isOpen ? "text-green-600" : "text-red-600"
+              }`}
+          >
+            {scheduleStatus.text}
+          </p>
         </div>
       </div>
     </header>

--- a/src/features/menu-billy-blanco-orlando/components/MenuSchedule.jsx
+++ b/src/features/menu-billy-blanco-orlando/components/MenuSchedule.jsx
@@ -1,0 +1,37 @@
+import { getDayName, formatScheduleTime } from "../helpers/schedule";
+
+export default function MenuSchedule({ schedule, language }) {
+  const groupedSchedules = schedule.map((scheduleBlock) => {
+    const dayNames = scheduleBlock.days.map((dayNum) =>
+      getDayName(dayNum, language)
+    );
+    const timeRange = formatScheduleTime(scheduleBlock.open, scheduleBlock.time);
+
+    return {
+      days: dayNames,
+      time: timeRange,
+    };
+  });
+
+  return (
+    <div className="bg-white rounded-lg p-6 shadow-sm border border-gray-200">
+      <h2 className="text-2xl font-bold text-gray-800 mb-4 pb-3 border-b-2 border-orange-500">
+        {language === "es" ? "Horarios" : "Schedule"}
+      </h2>
+
+      <div className="space-y-3">
+        {groupedSchedules.map((item, index) => (
+          <div
+            key={index}
+            className="flex flex-col sm:flex-row sm:justify-between sm:items-center p-3 rounded-lg bg-gray-50 hover:bg-orange-50 transition-colors"
+          >
+            <div className="font-medium text-gray-700 mb-1 sm:mb-0">
+              {item.days.join(", ")}
+            </div>
+            <div className="text-orange-600 font-semibold">{item.time}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/menu-billy-blanco-orlando/helpers/schedule.js
+++ b/src/features/menu-billy-blanco-orlando/helpers/schedule.js
@@ -1,0 +1,59 @@
+export function getScheduleStatus(schedule, language) {
+  const now = new Date();
+  const day = now.getDay();
+  const hour = now.getHours();
+  const minute = now.getMinutes();
+
+  const today = schedule.find((s) => s.days.includes(day));
+  const [openH, openM = 0] = today.open.split(":").map(Number);
+  const closeH = openH + parseInt(today.time);
+
+  const current = hour * 60 + minute;
+  const open = openH * 60 + openM;
+  const close = closeH * 60;
+
+  const isOpen = current >= open && current < close;
+  const closeTime = `${String(closeH).padStart(2, "0")}:00`;
+
+  return {
+    isOpen,
+    text: isOpen
+      ? language === "es"
+        ? `Abierto · Cierra a las ${closeTime}`
+        : `Open · Closes at ${closeTime}`
+      : language === "es"
+        ? `Cerrado · Abre a las ${today.open}`
+        : `Closed · Opens at ${today.open}`,
+  };
+}
+
+export function formatScheduleTime(openTime, duration) {
+  const openH = parseInt(openTime.split(":")[0]);
+  const closeH = openH + parseInt(duration);
+  return `${openTime} - ${String(closeH).padStart(2, "0")}:00`;
+}
+
+export function getDayName(dayNumber, language) {
+  const days = {
+    es: [
+      "Domingo",
+      "Lunes",
+      "Martes",
+      "Miércoles",
+      "Jueves",
+      "Viernes",
+      "Sábado",
+    ],
+    en: [
+      "Sunday",
+      "Monday",
+      "Tuesday",
+      "Wednesday",
+      "Thursday",
+      "Friday",
+      "Saturday",
+    ],
+  };
+
+  return days[language][dayNumber];
+}


### PR DESCRIPTION
## Descripción

Agregué la lógica completa de horarios del restaurante. El menú muestra si el negocio está abierto o cerrado según el día y la hora actual, calcula la hora de cierre y también indica cuándo vuelve a abrir. También reemplacé la URL del logo por una imagen valida.

## Tipo de cambio

- [ ] 🐛 Bug fix  
- [x] ✨ Nueva feature  
- [ ] 💄 Cambios de UI/estilo  
- [ ] ♻️ Refactoring  
- [ ] 📝 Documentación  
- [ ] ⚡ Mejora de performance  

## Cambios realizados

- Implementé helpers para manejar horarios.  
- Mostré el estado (abierto/cerrado) dentro del header.  
- Ajusté el mensaje para mostrar el nombre del día en lugar de un número.  
- Reemplacé la URL rota del logo por una imagen válida.

## Testing

- [x] Se realizaron pruebas locales  
- [x] Se verificó el build (`pnpm build`)  
- [x] Se verificó el linting (`pnpm lint`)  
- [x] Se verificó el formato (`pnpm format:check`)  
